### PR TITLE
Add Truck Factor Metric

### DIFF
--- a/scripts/truck-factor.py
+++ b/scripts/truck-factor.py
@@ -1,0 +1,84 @@
+import os
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import scan
+from settings.settings import ELASTIC_URL
+
+from db import get_cloned_repos
+from files import save_file
+from tqdm import tqdm
+
+
+FILENAME = f"{os.getcwd()}/scripts/truck-factor.json"
+
+files_modified_by_author = {}
+author_modified_by_files = {}
+
+es = Elasticsearch(ELASTIC_URL)
+
+def process_response(response):
+
+    author = response['_source']['data']['Author']
+    if author not in files_modified_by_author.keys():
+        files_modified_by_author[author] = set()
+
+    for file in response['_source']['data']['files']:
+        file_name = file['file']
+
+        if file_name not in author_modified_by_files.keys():
+            author_modified_by_files[file_name] = set()
+
+        author_modified_by_files[file_name].add(author)
+        files_modified_by_author[author].add(file_name)
+
+
+def get_number_of_commits_by_author(url: str):
+    files_modified_by_author.clear()
+    author_modified_by_files.clear()
+
+
+    query = {"query": {"match_phrase": {"origin": {"query": url}}}}
+
+    for hit in scan(es, index="git_raw", query=query):
+        process_response(hit)
+
+
+def get_result(url: str) -> dict:
+    get_number_of_commits_by_author(url)
+
+    sum = len(author_modified_by_files)
+
+    cnt_author = []
+
+    for author in files_modified_by_author:
+        cnt_author.append((author, len(files_modified_by_author[author])))
+
+    cnt_author.sort(key=lambda tup: tup[1], reverse=True)
+
+    curr_sum = 0
+    truck_factor = 0
+
+    for (author, _) in cnt_author:
+        truck_factor += 1
+        
+        for file in files_modified_by_author[author]:
+            author_modified_by_files[file].remove(author)
+
+            if (len(author_modified_by_files[file]) == 0):
+                curr_sum += 1
+
+            if (curr_sum > sum / 2.0):
+                return truck_factor
+        
+    return 0
+
+
+def generate_metric(repos: list) -> None:
+    results = {}
+    for repo in tqdm(repos):
+        results[repo.full_name] = get_result(repo.html_url)
+    save_file(results, FILENAME)
+
+
+if __name__ == "__main__":
+    repos = get_cloned_repos()
+    generate_metric(repos)


### PR DESCRIPTION
# Adding the Truck Factor Metric

- This metric answer the question _how many contributors can we lose before a project stalls?_

## Calculating the metric value

This metric is caculated following this algorithm:

1.  Get all files modified for each contibuitor.
2. Start by removing each author in order from the contributor who contributed the most files to the one who contributed the least files.
3. When we have more then `50%` of the original files without any contributors, the number of contributors removed it's the _Truck Factor_